### PR TITLE
Allow targets to specify output of the rule

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -42,6 +42,8 @@ pandoc_toolchain(
     src = "README.md",
     from_format = "markdown",
     to_format = fmt,
+    # TODO(regisd) Infer extension from to_format
+    output = "readme_" + fmt + "." + fmt,
 ) for fmt in [
     "asciidoc",
     "beamer",

--- a/COPYING
+++ b/COPYING
@@ -1,4 +1,6 @@
 Copyright 2018 Prodrive Technologies B.V.
+Copyright 2018 Google LLC.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/README.md
+++ b/README.md
@@ -35,16 +35,18 @@ You can then add directives along these lines to your `BUILD.bazel` files:
 load("@bazel_pandoc//:pandoc.bzl", "pandoc")
 
 pandoc(
-    name = "foo",
-    src = "foo.md",
-    from_format = "markdown",
-    to_format = "latex",
+    name = "foo",                # required
+    src = "foo.md",              # required
+    from_format = "markdown",    # optional, inferred from src extension by default
+    to_format = "latex",         # optional, inferred from output extension by default
+    output = "awesome_doc.tex",  # optional, derived from name and to_format by default
 )
 ```
 
-In the example above, an output file called `foo.tex` will be created in
-the `bazel-bin` directory. The `to_format` field is used to
-automatically derive a file extension of the output file.
+In the example above, an output file called `awesome_doc.tex` will be created
+in the `bazel-bin` directory.
+
+At least one of the `to_format` or `output`attributes must be provided.
 
 # Platform support
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ pandoc(
 In the example above, an output file called `awesome_doc.tex` will be created
 in the `bazel-bin` directory.
 
-At least one of the `to_format` or `output`attributes must be provided.
+At least one of the `to_format` or `output` attributes must be provided.
 
 # Platform support
 

--- a/pandoc.bzl
+++ b/pandoc.bzl
@@ -48,47 +48,60 @@ PANDOC_EXTENSIONS = {
     "textile": "textile",
     "zimwiki": "txt",
 }
+PANDOC_FORMATS = PANDOC_EXTENSIONS.keys()
 
 def _pandoc_impl(ctx):
     toolchain = ctx.toolchains["@bazel_pandoc//:pandoc_toolchain_type"]
+    cli_args = []
+    cli_args.extend(ctx.attr.options)
+    if ctx.attr.from_format:
+        cli_args.extend(["--from", ctx.attr.from_format])
+    if ctx.attr.to_format:
+        cli_args.extend(["--to", ctx.attr.to_format])
+    cli_args.extend(["-o", ctx.outputs.output.path])
+    cli_args.extend([ctx.files.src[0].path])
     ctx.actions.run(
         mnemonic = "Pandoc",
         executable = toolchain.pandoc.files.to_list()[0].path,
-        arguments = ctx.attr.options + [
-            "--from",
-            ctx.attr.from_format,
-            "--to",
-            ctx.attr.to_format,
-            "-o",
-            ctx.outputs.out.path,
-            ctx.files.src[0].path,
-        ],
+        arguments = cli_args,
         inputs = depset(
             direct = ctx.files.src,
             transitive = [toolchain.pandoc.files],
         ),
-        outputs = [ctx.outputs.out],
+        outputs = [ctx.outputs.output],
     )
 
 _pandoc = rule(
     attrs = {
-        "extension": attr.string(),
         "from_format": attr.string(),
         "options": attr.string_list(),
         "src": attr.label(allow_files = True),
         "to_format": attr.string(),
+        "output": attr.output(mandatory = True),
     },
-    outputs = {"out": "%{name}.%{extension}"},
     toolchains = ["@bazel_pandoc//:pandoc_toolchain_type"],
     implementation = _pandoc_impl,
 )
 
-def pandoc(**kwargs):
-    # Derive extension of the output file based on the desired format.
-    # Use the generic .xml syntax for XML-based formats and .txt for
-    # ones with no commonly used extension.
-    to_format = kwargs["to_format"]
-    if to_format not in PANDOC_EXTENSIONS:
-        fail("Unknown output format: " + to_format)
+def _check_format(format, attr_name):
+    if format not in PANDOC_EXTENSIONS:
+        fail("Unknown %{attr} format: %{format}".fmt(attr = attr_name, format = format))
+    return format
 
-    _pandoc(extension = PANDOC_EXTENSIONS[to_format], **kwargs)
+def _infer_output(name, to_format):
+    """Derives output file based on the desired format.
+
+    Use the generic .xml syntax for XML-based formats and .txt for
+    ones with no commonly used extension.
+    """
+    to_format = _check_format(to_format, "to_format")
+    ext = PANDOC_EXTENSIONS[to_format]
+    return name + "." + ext
+
+def pandoc(**kwargs):
+    if "from_format" in kwargs:
+        _check_format(kwargs["from_format"], "from_format")
+    if "output" not in kwargs:
+        to_format = _check_format(kwargs["to_format"], "to_format")
+        kwargs["output"] = _infer_output(kwargs["name"], to_format)
+    _pandoc(**kwargs)

--- a/pandoc.bzl
+++ b/pandoc.bzl
@@ -75,7 +75,7 @@ _pandoc = rule(
     attrs = {
         "from_format": attr.string(),
         "options": attr.string_list(),
-        "src": attr.label(allow_files = True),
+        "src": attr.label(allow_single_file = True, mandatory = True),
         "to_format": attr.string(),
         "output": attr.output(mandatory = True),
     },

--- a/pandoc.bzl
+++ b/pandoc.bzl
@@ -9,7 +9,7 @@ def _pandoc_impl(ctx):
     cli_args.extend(["-o", ctx.outputs.output.path])
     cli_args.append(ctx.file.src.path)
 
-    print("args=" + str(cli_args))
+    # print("args=" + str(cli_args))
     ctx.actions.run(
         mnemonic = "Pandoc",
         executable = toolchain.pandoc.files.to_list()[0].path,

--- a/pandoc.bzl
+++ b/pandoc.bzl
@@ -48,7 +48,6 @@ PANDOC_EXTENSIONS = {
     "textile": "textile",
     "zimwiki": "txt",
 }
-PANDOC_FORMATS = PANDOC_EXTENSIONS.keys()
 
 def _pandoc_impl(ctx):
     toolchain = ctx.toolchains["@bazel_pandoc//:pandoc_toolchain_type"]
@@ -59,7 +58,7 @@ def _pandoc_impl(ctx):
     if ctx.attr.to_format:
         cli_args.extend(["--to", ctx.attr.to_format])
     cli_args.extend(["-o", ctx.outputs.output.path])
-    cli_args.extend([ctx.files.src[0].path])
+    cli_args.extend([ctx.file.src.path])
     ctx.actions.run(
         mnemonic = "Pandoc",
         executable = toolchain.pandoc.files.to_list()[0].path,

--- a/pandoc.bzl
+++ b/pandoc.bzl
@@ -85,7 +85,7 @@ _pandoc = rule(
 
 def _check_format(format, attr_name):
     if format not in PANDOC_EXTENSIONS:
-        fail("Unknown %{attr} format: %{format}".fmt(attr = attr_name, format = format))
+        fail("Unknown `%{attr}` format: %{format}".fmt(attr = attr_name, format = format))
     return format
 
 def _infer_output(name, to_format):
@@ -99,9 +99,9 @@ def _infer_output(name, to_format):
     return name + "." + ext
 
 def pandoc(**kwargs):
-    if "from_format" in kwargs:
-        _check_format(kwargs["from_format"], "from_format")
     if "output" not in kwargs:
+        if "to_format" not in kwargs:
+            fail("One of `output` or `to_format` attributes must be provided")
         to_format = _check_format(kwargs["to_format"], "to_format")
         kwargs["output"] = _infer_output(kwargs["name"], to_format)
     _pandoc(**kwargs)

--- a/sample/BUILD.bazel
+++ b/sample/BUILD.bazel
@@ -1,7 +1,20 @@
 load("//:pandoc.bzl", "PANDOC_EXTENSIONS", "pandoc")
 
-# Conversion of README to various formats for testing.
+# Simplest possible example, where the to_format is specified
+pandoc(
+    name = "readme1",
+    src = "//:README.md",
+    to_format = "asciidoc",
+)
 
+# Simplest possible example, where the output is specified
+pandoc(
+    name = "readme2",
+    src = "//:README.md",
+    output = "readme2.html",
+)
+
+# Conversion of README to various formats for testing.
 [pandoc(
     name = "readme_" + fmt,
     src = "//:README.md",

--- a/sample/BUILD.bazel
+++ b/sample/BUILD.bazel
@@ -1,19 +1,5 @@
 load("//:pandoc.bzl", "PANDOC_EXTENSIONS", "pandoc")
 
-# Simplest possible example, where the to_format is specified
-pandoc(
-    name = "readme1",
-    src = "//:README.md",
-    to_format = "asciidoc",
-)
-
-# Simplest possible example, where the output is specified
-pandoc(
-    name = "readme2",
-    src = "//:README.md",
-    output = "readme2.html",
-)
-
 # Conversion of README to various formats for testing.
 [pandoc(
     name = "readme_" + fmt,
@@ -21,3 +7,11 @@ pandoc(
     from_format = "markdown",
     to_format = fmt,
 ) for fmt in PANDOC_EXTENSIONS.keys()]
+
+# You can also specify the output, the format is then inferred from the extension,
+# and the rule name is not used.
+pandoc(
+    name = "gen_html_page",
+    src = "//:README.md",
+    output = "index.html",
+)

--- a/sample/README.md
+++ b/sample/README.md
@@ -3,6 +3,9 @@
 Once you have set up your workspace,
 you can generate the [README](../README.md) in a multitude of formats.
 
+
+## Target defined with `to_format`
+
 For instance:
 
 ```sh
@@ -11,7 +14,57 @@ bazel build @bazel_pandoc//sample:readme_html
 bazel build @bazel_pandoc//sample:readme_epub
 ```
 
-You can also produce the README in all formats know to the rule:
+These targets are defined (actually with a _for loop_) with
+
+```python
+pandoc(
+    name = "readme_plain",
+    src = "//:README.md",
+    from_format = "markdown",
+    to_format = "plain",
+)
+pandoc(
+    name = "readme_html",
+    src = "//:README.md",
+    from_format = "markdown",
+    to_format = "html",
+)
+pandoc(
+    name = "readme_epub",
+    src = "//:README.md",
+    from_format = "markdown",
+    to_format = "epub",
+)
+```
+
+You notice that the output file is derived from the rule name:
+- bazel-bin/sample/readme_plain.txt
+- bazel-bin/sample/readme_html.html
+- bazel-bin/sample/readme_epub.epub
+
+NB: `from_format` is optional and inferred from the file extension by default.
+
+
+## Target defined with `output`
+
+It's also possible to specify the output
+
+```python
+pandoc(
+    name = "gen_html_page",
+    src = "//:README.md",
+    output = "index.html",
+)
+
+```
+As a result,
+```sh
+bazel build //sample:gen_html_page
+```
+produces an HTML document in:
+- bazel-bin/sample/index.html
+
+Finally can also produce the README in all formats know to the rule:
 
 ```sh
 bazel build @bazel_pandoc//sample/...


### PR DESCRIPTION
It's important that users of the rule can change the output.

For instance, we want to be able to generate "manual.html" and "manual.txt":
```
pandoc(
  name = "html",
  src " manual.md",
  from_format = "markdown",
  to_format = "html",
)
pandoc(
  name = "txt",
  src " manual.md",
  from_format = "markdown",
  to_format = "plain",
)
```

Today, the rule forces the output to be `html.html` and `txt.txt`.

Of course, you can argue that the name of the rule is used, and I could have "manual.html". However, two labels cannot be identical, so there is no easy way to generate "manual.txt".
A workaround could be to add a genrule that copies "txt.txt" to "manual.txt".

Instead, I propose to replace the pattern generated `ctx.outputs` by an `output` given in `ctx.attr`.

Also, this change makes `src` single file and mandatory.
