### PR TITLE
Generation of HTML documents with custom CSS

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,6 +2,7 @@ load(":toolchain.bzl", "pandoc_toolchain")
 load(":pandoc.bzl", "PANDOC_EXTENSIONS", "pandoc")
 
 exports_files(["README.md"])
+exports_files(["stylesheet.css"])
 
 # Precompiled Pandoc binaries provided by upstream.
 

--- a/pandoc.bzl
+++ b/pandoc.bzl
@@ -77,7 +77,7 @@ _pandoc = rule(
         "from_format": attr.string(),
         "options": attr.string_list(),
         "src": attr.label(allow_single_file = True, mandatory = True),
-	"css": attr.label(allow_single_file = True, mandatory = False),
+        "css": attr.label(allow_single_file = True, mandatory = False),
         "to_format": attr.string(),
         "output": attr.output(mandatory = True),
     },

--- a/pandoc.bzl
+++ b/pandoc.bzl
@@ -57,6 +57,8 @@ def _pandoc_impl(ctx):
         cli_args.extend(["--from", ctx.attr.from_format])
     if ctx.attr.to_format:
         cli_args.extend(["--to", ctx.attr.to_format])
+        if ctx.attr.css and PANDOC_EXTENSIONS[ctx.attr.to_format] == "html":
+            cli_args.extend(["-css", ctx.file.css.path])
     cli_args.extend(["-o", ctx.outputs.output.path])
     cli_args.extend([ctx.file.src.path])
     ctx.actions.run(
@@ -64,7 +66,7 @@ def _pandoc_impl(ctx):
         executable = toolchain.pandoc.files.to_list()[0].path,
         arguments = cli_args,
         inputs = depset(
-            direct = ctx.files.src,
+            direct = ctx.files.src + ctx.files.css,
             transitive = [toolchain.pandoc.files],
         ),
         outputs = [ctx.outputs.output],
@@ -75,6 +77,7 @@ _pandoc = rule(
         "from_format": attr.string(),
         "options": attr.string_list(),
         "src": attr.label(allow_single_file = True, mandatory = True),
+	"css": attr.label(allow_single_file = True, mandatory = False),
         "to_format": attr.string(),
         "output": attr.output(mandatory = True),
     },

--- a/sample/BUILD.bazel
+++ b/sample/BUILD.bazel
@@ -4,6 +4,7 @@ load("//:pandoc.bzl", "PANDOC_EXTENSIONS", "pandoc")
 [pandoc(
     name = "readme_" + fmt,
     src = "//:README.md",
+    css = "//:stylesheet.css",
     from_format = "markdown",
     to_format = fmt,
 ) for fmt in PANDOC_EXTENSIONS.keys()]

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,0 +1,9 @@
+<style type="text/css">
+html, body {
+	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+	font-size: 14px;
+	line-height: 1.4;
+	color: #333;
+	background-color: #eee;
+}
+</style>


### PR DESCRIPTION
As requested in an issue, this PR implements the ability to generate HTML documents with custom CSS defined in a separate stylesheet.

The output can be reproduced by running: `bazel build @bazel_pandoc//sample/...`

Known limitations (a.k.a. improvements which could be implemented before merging with master):
1. Only works when `to_format` is specified in your rule. This limitation was added because otherwise the `--css`-flag is also appended for non-HTML files. This results in an error for some conversions. In fact, this limitation could be resolved by using `-c' instead, but then the CSS is somehow not included.
2. Standalone flag `-s` could be added, but then `bazel-pandoc` should also output the CSS file itself.