### PR TITLE
Add support for css and data attributes that correctly declare and generate inputs and outputs. Support Pandoc --standalone and --self-contained

### DIFF
--- a/pandoc.bzl
+++ b/pandoc.bzl
@@ -77,7 +77,7 @@ def _pandoc_impl(ctx):
         executable = toolchain.pandoc.files.to_list()[0].path,
         arguments = cli_args,
         inputs = depset(
-            direct = ctx.attr.src.files.to_list() + ctx.attr.css.files.to_list(),
+            direct = ctx.attr.src.files.to_list(),
             transitive = [toolchain.pandoc.files],
         ),
         outputs = [ctx.outputs.output],

--- a/pandoc.bzl
+++ b/pandoc.bzl
@@ -60,14 +60,13 @@ def _pandoc_impl(ctx):
         cli_args.extend(["--from", ctx.attr.from_format])
     if ctx.attr.to_format:
         cli_args.extend(["--to", ctx.attr.to_format])
-    if ctx.attr.css and PANDOC_EXTENSIONS[ctx.attr.to_format] == "html":
+    if ctx.attr.css:
         all_data_inputs.extend([ctx.attr.css])
         cli_args.extend(["-c", ctx.file.css.path])
     cli_args.extend(["-o", ctx.outputs.output.path])
     cli_args.extend([ctx.file.src.path])
     for target in all_data_inputs:
         for df in target.files.to_list():
-            print(df)
             outfile = ctx.actions.declare_file(df.path)
             all_outputs.extend([outfile])
             ctx.actions.expand_template(template=df,

--- a/pandoc.bzl
+++ b/pandoc.bzl
@@ -66,12 +66,12 @@ def _pandoc_impl(ctx):
         cli_args.extend(["--to", ctx.attr.to_format])
     if ctx.attr.css:
         pandoc_inputs.extend([ctx.file.css])
-        cli_args.extend(["-c", ctx.file.css.path])
+        cli_args.extend(["-c", ctx.file.css.basename])
         if not ctx.attr.self_contained:
             data_inputs.extend([ctx.file.css])
     cli_args.extend(["-o", ctx.outputs.output.path])
     cli_args.extend(["--resource-path",
-                     ctx.label.workspace_root])
+                     ctx.label.package])
     for target in ctx.attr.data:
         for df in target.files.to_list():
             if ctx.attr.self_contained:

--- a/pandoc.bzl
+++ b/pandoc.bzl
@@ -1,3 +1,4 @@
+"Bazel Pandoc rule"
 PANDOC_EXTENSIONS = {
     "asciidoc": "adoc",
     "beamer": "tex",
@@ -133,6 +134,10 @@ def _infer_output(name, to_format):
     return name + "." + ext
 
 def pandoc(**kwargs):
+"""Call Pandoc.
+    Args:
+        **kwargs: kwargs
+"""
     if "output" not in kwargs:
         if "to_format" not in kwargs:
             fail("One of `output` or `to_format` attributes must be provided")

--- a/pandoc.bzl
+++ b/pandoc.bzl
@@ -134,10 +134,11 @@ def _infer_output(name, to_format):
     return name + "." + ext
 
 def pandoc(**kwargs):
-"""Call Pandoc.
+    """Call Pandoc.
+
     Args:
         **kwargs: kwargs
-"""
+    """
     if "output" not in kwargs:
         if "to_format" not in kwargs:
             fail("One of `output` or `to_format` attributes must be provided")

--- a/pandoc.bzl
+++ b/pandoc.bzl
@@ -85,7 +85,7 @@ def _pandoc_impl(ctx):
                                     output = outfile,
                                     substitutions={})
     cli_args.extend(ctx.attr.options)
-    cli_args.extend([ctx.file.src.path])
+    cli_args.extend([f.path for f in ctx.attr.src.files.to_list()])
     ctx.actions.run(
         mnemonic = "Pandoc",
         executable = toolchain.pandoc.files.to_list()[0].path,

--- a/pandoc.bzl
+++ b/pandoc.bzl
@@ -79,7 +79,7 @@ def _pandoc_impl(ctx):
             else:
                 data_inputs.append(df)
     for df in data_inputs:
-        outfile = ctx.actions.declare_file(df.path)
+        outfile = ctx.actions.declare_file(df.basename)
         data_outputs.extend([outfile])
         ctx.actions.expand_template(template=df,
                                     output = outfile,


### PR DESCRIPTION
This is based on https://github.com/ProdriveTechnologies/bazel-pandoc/pull/13 but fixes the issues pending there, it also adds a "data" attribute that can be used to declare stuff like images and other media referenced in the doc, and have them copied over as runfiles,
