### PR TITLE
Updates pandoc to 3.1.13 and modern platforms.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,4 @@
 load(":toolchain.bzl", "pandoc_toolchain")
-load(":pandoc.bzl", "PANDOC_EXTENSIONS", "pandoc")
 
 exports_files(["README.md"])
 
@@ -12,32 +11,40 @@ toolchain_type(
 
 pandoc_toolchain(
     exec_compatible_with = [
-        "@bazel_tools//platforms:linux",
-        "@bazel_tools//platforms:x86_64",
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
     ],
     platform = "linux-x86_64",
 )
 
 pandoc_toolchain(
     exec_compatible_with = [
-        "@bazel_tools//platforms:osx",
-        "@bazel_tools//platforms:x86_64",
+        "@platforms//os:linux",
+        "@platforms//cpu:arm64",
     ],
-    platform = "macOS",
+    platform = "linux-arm64",
 )
 
 pandoc_toolchain(
     exec_compatible_with = [
-        "@bazel_tools//platforms:windows",
-        "@bazel_tools//platforms:x86_32",
+        "@platforms//os:osx",
+        "@platforms//cpu:arm64",
     ],
-    platform = "windows-i386",
+    platform = "macOS-arm64",
 )
 
 pandoc_toolchain(
     exec_compatible_with = [
-        "@bazel_tools//platforms:windows",
-        "@bazel_tools//platforms:x86_64",
+        "@platforms//os:osx",
+        "@platforms//cpu:x86_64",
+    ],
+    platform = "macOS-x86_64",
+)
+
+pandoc_toolchain(
+    exec_compatible_with = [
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
     ],
     platform = "windows-x86_64",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,13 +3,12 @@ workspace(name = "bazel_pandoc")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "bazel_toolchains",
-    sha256 = "4329663fe6c523425ad4d3c989a8ac026b04e1acedeceb56aa4b190fa7f3973c",
-    strip_prefix = "bazel-toolchains-bc09b995c137df042bb80a395b73d7ce6f26afbe",
+    name = "platforms",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/bc09b995c137df042bb80a395b73d7ce6f26afbe.tar.gz",
-        "https://github.com/bazelbuild/bazel-toolchains/archive/bc09b995c137df042bb80a395b73d7ce6f26afbe.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
+        "https://github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
     ],
+    sha256 = "218efe8ee736d26a3572663b374a253c012b716d8af0c07e842e82f238a0a7ee",
 )
 
 load("//:repositories.bzl", "pandoc_repositories")

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -1,6 +1,6 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-PANDOC_VERSION = "2.8.0.1"
+PANDOC_VERSION = "3.1.13"
 
 BUILD_CONTENT_UNIX = """
 filegroup(
@@ -18,38 +18,48 @@ filegroup(
 
 def pandoc_repositories():
     http_archive(
+        name = "pandoc_bin_linux-arm64",
+        build_file_content = BUILD_CONTENT_UNIX,
+        sha256 = "678c09ac4227c88b491f6e75491e6da871fd08d79b8c0f0ee37b611f01ad3d25",
+        strip_prefix = "pandoc-{v}".format(v = PANDOC_VERSION),
+        url = "https://github.com/jgm/pandoc/releases/download/{v}/pandoc-{v}-linux-arm64.tar.gz".format(v = PANDOC_VERSION),
+    )
+
+    http_archive(
         name = "pandoc_bin_linux-x86_64",
         build_file_content = BUILD_CONTENT_UNIX,
-        sha256 = "8ebf1b6c852d77290345afdd565547bdbd5de7888362f5a69fc7f51aeb8696a2",
+        sha256 = "db556c98cf207d2fddc088d12d2e2f367d9401784d4a3e914b068fa895dcf3f0",
         strip_prefix = "pandoc-{v}".format(v = PANDOC_VERSION),
         url = "https://github.com/jgm/pandoc/releases/download/{v}/pandoc-{v}-linux-amd64.tar.gz".format(v = PANDOC_VERSION),
     )
 
     http_archive(
-        name = "pandoc_bin_macOS",
+        name = "pandoc_bin_macOS-x86_64",
         build_file_content = BUILD_CONTENT_UNIX,
-        sha256 = "477d2f436170ecccd33e741516e01f053c8d0b141e7a9a4c26c09d07f62a080f",
-        strip_prefix = "pandoc-{v}".format(v = PANDOC_VERSION),
-        url = "https://github.com/jgm/pandoc/releases/download/{v}/pandoc-{v}-macOS.zip".format(v = PANDOC_VERSION),
+        sha256 = "324995643ab4273be9b52e1bfd88f4909d9238f3dafd49cb1681a8ca374336bd",
+        strip_prefix = "pandoc-{v}-x86_64".format(v = PANDOC_VERSION),
+        url = "https://github.com/jgm/pandoc/releases/download/{v}/pandoc-{v}-x86_64-macOS.zip".format(v = PANDOC_VERSION),
     )
 
     http_archive(
-        name = "pandoc_bin_windows-i386",
-        build_file_content = BUILD_CONTENT_WINDOWS,
-        sha256 = "c1530b141bd98903fa0f3d242076d790ce9d7448e8fc24f5084967c0889238d6",
-        url = "https://github.com/jgm/pandoc/releases/download/{v}/pandoc-{v}-windows-i386.zip".format(v = PANDOC_VERSION),
+        name = "pandoc_bin_macOS-arm64",
+        build_file_content = BUILD_CONTENT_UNIX,
+        sha256 = "76b1722c81f0f9349b6eef1bf387226f2eb277a7ed47641475b9edb53403b980",
+        strip_prefix = "pandoc-{v}-arm64".format(v = PANDOC_VERSION),
+        url = "https://github.com/jgm/pandoc/releases/download/{v}/pandoc-{v}-arm64-macOS.zip".format(v = PANDOC_VERSION),
     )
 
     http_archive(
         name = "pandoc_bin_windows-x86_64",
         build_file_content = BUILD_CONTENT_WINDOWS,
-        sha256 = "ce9f8a68b9bccbec63d35317dfdc40dc3e1722d49b66b9cf39cc1459ae688129",
+        sha256 = "347b250e855d0cb4bf9e7dcda3b55a2b5bdae588e637a363810008b75be5ca81",
         url = "https://github.com/jgm/pandoc/releases/download/{v}/pandoc-{v}-windows-x86_64.zip".format(v = PANDOC_VERSION),
     )
 
     native.register_toolchains(
+        "@bazel_pandoc//:pandoc_toolchain_linux-arm64",
         "@bazel_pandoc//:pandoc_toolchain_linux-x86_64",
-        "@bazel_pandoc//:pandoc_toolchain_macOS",
-        "@bazel_pandoc//:pandoc_toolchain_windows-i386",
+        "@bazel_pandoc//:pandoc_toolchain_macOS-arm64",
+        "@bazel_pandoc//:pandoc_toolchain_macOS-x86_64",
         "@bazel_pandoc//:pandoc_toolchain_windows-x86_64",
     )

--- a/toolchain.bzl
+++ b/toolchain.bzl
@@ -9,7 +9,7 @@ _pandoc_toolchain_info = rule(
     attrs = {
         "pandoc": attr.label(
             allow_single_file = True,
-            cfg = "host",
+            cfg = "exec",
             executable = True,
         ),
     },


### PR DESCRIPTION
tl;dr This makes the rules useable again.

* Fixes errors related to platforms being moved to a separate repo.
* Updates Pandoc to v3.1.13 to support all the platforms Pandoc provides builds for. Supported pandoc platforms:
    * linux-amd64
    * linux-arm64
    * macos-arm64
    * macos-x86_64
    * window-x86_64
* Removes the windows-i386 platform as Pandoc no longer supports 32-bit platforms.
* Fixes lint errors except adding docstrings.